### PR TITLE
With coordintes file including many "data_instances" the longest entry is considered to be main model

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,6 @@ Converter explicitly parser through the PDBx definitions to extract as much data
 * administrative categories sorted within mmCIF ( such as author information, grant, etc)
 * em-related categories are sorted randomly, as there is no definitive sorting in PDB team as well
 * file ends with information on atoms
-* units in OSCEM definition are comared to PDBx ( converter for units will be implemented)
+* units in OSCEM definition are compared to PDBx ( converter for units will be implemented)
 * numeric values are checked to be within a range allowed by PDBs
 * values  are checked to be within a list of attributes allowed by PDBx. This is additionally enhanced to match via regular expressions or ceratin logic. 

--- a/parser/writeMmCif.go
+++ b/parser/writeMmCif.go
@@ -305,7 +305,7 @@ func getOrderCategories(parsedCategories []string, mmCIFCategories []string) []s
 	}
 	// add the rest not atom-related in some order (it can be random)
 	for _, c := range allCategories {
-		if !converterUtils.SliceContains(order, c) && !converterUtils.SliceContains(converterUtils.PDBxCategoriesOrderAtom, c[1:]) && c[0:5] != "data_" {
+		if !converterUtils.SliceContains(order, c) && !converterUtils.SliceContains(converterUtils.PDBxCategoriesOrderAtom, c[1:]) && (len(c) > 5 && c[0:5] != "data_") {
 			order = append(order, c)
 		}
 
@@ -331,7 +331,7 @@ func parseMmCIF(dictFile *os.File) (string, map[string]string, error) {
 
 	var longestData uint32 = 0
 	var dataToStr = make(map[string]string, 0)
-	var mmCIFfieldsMain *map[string]string // should always point to the main model
+	var mmCIFfieldsMain map[string]string // should always point to the main model
 	var longestNameData string
 	// initialize first category
 	scanner.Scan()
@@ -339,7 +339,7 @@ func parseMmCIF(dictFile *os.File) (string, map[string]string, error) {
 	// first run
 	longestNameData = firstName
 	mmCIFfields, bigString, l, new_data := LoopDataEntry(scanner, firstName)
-	mmCIFfieldsMain = &mmCIFfields
+	mmCIFfieldsMain = mmCIFfields
 	dataToStr[firstName] = bigString
 	longestData = l
 
@@ -347,7 +347,7 @@ func parseMmCIF(dictFile *os.File) (string, map[string]string, error) {
 		mmCIFfields, s, l, d := LoopDataEntry(scanner, new_data)
 		dataToStr[new_data] = s
 		if l > longestData {
-			mmCIFfieldsMain = &mmCIFfields
+			mmCIFfieldsMain = mmCIFfields
 			longestNameData = new_data
 		}
 		new_data = d
@@ -356,11 +356,11 @@ func parseMmCIF(dictFile *os.File) (string, map[string]string, error) {
 	for k, v := range dataToStr {
 		if k != longestNameData {
 			// add the data_prefix back
-			(*mmCIFfieldsMain)[k] = k + "\n" + v
+			mmCIFfieldsMain[k] = k + "\n" + v
 		}
 	}
 
-	return longestNameData, mmCIFfields, nil
+	return longestNameData, mmCIFfieldsMain, nil
 }
 
 func LoopDataEntry(scanner *bufio.Scanner, category string) (map[string]string, string, uint32, string) { // return the categories, same as long string, the length and next category


### PR DESCRIPTION
## Description: 
For cases where a user provides a coordinate file with many instances of "data_" present, for instance, ligands, the converter will parse categories of the longest instance only. This longest data_ instance is assumed to be main model. It will be parsed, categories will be updated in case they were also present in metadata and additional scientific metadata will be added to it. 
Other data_ instances will be simply copied.

Still needs tests.  