### PR TITLE
feat: use the  data from coordinates files when many entities present in both metadata and given cif

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,7 @@
 module github.com/osc-em/converter-OSCEM-to-mmCIF
 
-go 1.22.1
+go 1.23.0
 
-require (
-	github.com/BurntSushi/cif v0.0.0-20140118173227-e459106941ba // indirect
-	golang.org/x/sys v0.4.0 // indirect
-	golang.org/x/tools v0.5.1-0.20230111220935-a7f7db3f17fc // indirect
-	golang.org/x/tools/cmd/cover v0.1.0-deprecated // indirect
-)
+toolchain go1.23.8
+
+require golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,2 @@
-github.com/BurntSushi/cif v0.0.0-20140118173227-e459106941ba h1:c+eqYI4ijTOXXT9ANIu27xpmH433UDEbVAksAeHtFEI=
-github.com/BurntSushi/cif v0.0.0-20140118173227-e459106941ba/go.mod h1:iGuSD07zGCQj4AkL2Y6Y1wfurc+nfeiMJb/L6y0CaIA=
-golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
-golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.5.1-0.20230111220935-a7f7db3f17fc h1:zRn9MzwG18RZhyanShCfUwJTcobvqw8fOjjROFN9jtM=
-golang.org/x/tools v0.5.1-0.20230111220935-a7f7db3f17fc/go.mod h1:N+Kgy78s5I24c24dU8OfWNEotWjutIs8SnJvn5IDq+k=
-golang.org/x/tools/cmd/cover v0.1.0-deprecated h1:Rwy+mWYz6loAF+LnG1jHG/JWMHRMMC2/1XX3Ejkx9lA=
-golang.org/x/tools/cmd/cover v0.1.0-deprecated/go.mod h1:hMDiIvlpN1NoVgmjLjUJE9tMHyxHjFX7RuQ+rW12mSA=
+golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 h1:R84qjqJb5nVJMxqWYb3np9L5ZsaDtB+a39EqjV0JSUM=
+golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0/go.mod h1:S9Xr4PYopiDyqSyp5NjCrhFrqg6A5zA2E/iPHPhqnS8=

--- a/parser/convert.go
+++ b/parser/convert.go
@@ -20,9 +20,9 @@ func getValues[K string, V string](m map[string]string) []string {
 	}
 	return values
 }
-func PDBconvertFromFile(scientificMetadata map[string]any, metadataLevelNameInJson string, conversionFile string, dictFile string, mmCIFInput *os.File) (string, error) {
+func PDBconvertFromReader(scientificMetadata map[string]any, metadataLevelNameInJson string, conversionFile string, dictFile string, mmCIFInput io.Reader) (string, error) {
 	mapper, PDBxdictvalues, jsonMeta, jsonUnits := parseInputs(scientificMetadata, metadataLevelNameInJson, conversionFile, dictFile)
-	mmCIFText, err := SupplementCoordinatesFromFile(mapper, PDBxdictvalues, jsonMeta, jsonUnits, mmCIFInput)
+	mmCIFText, err := SupplementCoordinates(mapper, PDBxdictvalues, jsonMeta, jsonUnits, mmCIFInput)
 	if err != nil {
 		return "", err
 	}

--- a/parser/validateCheckers_test.go
+++ b/parser/validateCheckers_test.go
@@ -1,0 +1,132 @@
+package parser
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/osc-em/converter-OSCEM-to-mmCIF/converterUtils"
+)
+
+func TestValidateDateIsRFC3339(t *testing.T) {
+	var testDate = []struct {
+		name           string
+		date           string
+		expectedResult string
+	}{
+		{"date is in correct format UTC+3", "2020-12-09T16:09:53+03:00", "2020-12-09"},
+		{"date is in correct format UTC+0 Z", "2020-12-09T16:09:53Z", "2020-12-09"},
+		{"date is in correct format UTC+0", "2020-12-09T16:09:53+02:00", "2020-12-09"},
+		{"date is in correct format UTC-1", "2020-12-09T16:09:53-01:00", "2020-12-09"},
+		{"date is in correct format but space instead of T does not work in time.Parse!", "2020-12-09 16:09:53-01:00", ""},
+		{"date is in correct format date only but no specified time- does not work in time.Parse!", "2020-12-09", ""},
+		{"date is in wrong format", "July, 17th 2017", ""},
+	}
+
+	for _, test := range testDate {
+
+		testname := fmt.Sprintf("%v", test.name)
+		t.Run(testname, func(t *testing.T) {
+			gotValue := validateDateIsRFC3339(test.date)
+
+			if gotValue != test.expectedResult {
+				t.Errorf("got %v, want %v", gotValue, test.expectedResult)
+			}
+		})
+	}
+}
+
+func TestValidateRange(t *testing.T) {
+	var testRange = []struct {
+		name           string
+		value          string
+		dataItem       converterUtils.PDBxItem
+		unitOSCEM      string
+		nameOSCEM      string
+		expectedResult bool
+		expectedError  string
+	}{
+		{"no units defined in OSCEM and PDBx", "27", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "", ValueType: "float", RangeMin: "0", RangeMax: "300", EnumValues: []string{}, PDBxEnumValues: []string{}}, "", "myOSCEMname", true, ""},
+		{"no units defined in OSCEM", "0.7", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "%", ValueType: "float", RangeMin: "0", RangeMax: "100", EnumValues: []string{}, PDBxEnumValues: []string{}}, "", "myOSCEMname", true, "No units defined for myOSCEMname in OSCEM! Analogous property cat1.name1 in PDBx has % units. Value will still be used in mmCIF file!"},
+		{"no units defined in PDBx", "5", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "", ValueType: "float", RangeMin: "0", RangeMax: "1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "Da", "myOSCEMname", true, "No units defined for cat1.name1 in PDBx! Analogous property myOSCEMname in OSCEM has Da units. Value will still be used in mmCIF file!"},
+		{"no explicit name of units defined in OSCEM", "0.5", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "mol", ValueType: "float", RangeMin: "0", RangeMax: "1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "mM", "myOSCEMname", true, "No explicit unit name is specified for property myOSCEMname in OSCEM, only a short name mM. Value will still be used in mmCIF file!"},
+		{"units don't match in OSCEM and PDBx", "2", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "second", ValueType: "float", RangeMin: "0", RangeMax: "10", EnumValues: []string{}, PDBxEnumValues: []string{}}, "s", "myOSCEMname", true, "Units for analogous properties myOSCEMname in OSCEM and cat1.name1 in PDBx  don't match! Implement a converter from s in OSCEM to second expected by PDBx. Value will still be used in mmCIF file!"},
+		{"units match but value not numeric", "zero", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "electron_volts", ValueType: "float", RangeMin: "-1", RangeMax: "1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "eV", "myOSCEMname", false, "JSON value zero not numeric, but supposed to be"},
+		{"units match but value is greater than maximum allowed in PDBx", "10", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "electron_volts", ValueType: "float", RangeMin: "-1", RangeMax: "1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "eV", "myOSCEMname", false, ""},
+		{"units match but value is smaller than minimum allowed in PDBx", "-1.2", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "electron_volts", ValueType: "float", RangeMin: "-1", RangeMax: "1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "eV", "myOSCEMname", false, ""},
+		{"units match and tange undefined by PDBx", "0", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "electron_volts", ValueType: "float", EnumValues: []string{}, PDBxEnumValues: []string{}}, "eV", "myOSCEMname", true, ""},
+		{"units match and value is in range allowed by PDBx", "0", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "electron_volts", ValueType: "float", RangeMin: "-1", RangeMax: "1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "eV", "myOSCEMname", true, ""},
+		{"units match and value is in range allowed by PDBx (no max)", "0", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "electron_volts", ValueType: "float", RangeMin: "-1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "eV", "myOSCEMname", true, ""},
+		{"units match and value is in range allowed by PDBx (no min)", "0", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "electron_volts", ValueType: "float", RangeMax: "1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "eV", "myOSCEMname", true, ""},
+	}
+
+	for _, test := range testRange {
+
+		testname := fmt.Sprintf("%v", test.name)
+		t.Run(testname, func(t *testing.T) {
+			gotValue, gotError := validateRange(test.value, test.dataItem, test.unitOSCEM, test.nameOSCEM)
+
+			if gotError != nil {
+				if gotError.Error() != test.expectedError {
+					t.Errorf("got error %v, wanted %v", gotError.Error(), test.expectedError)
+				}
+			}
+			if gotValue != test.expectedResult {
+				t.Errorf("got %v, want %v", gotValue, test.expectedResult)
+			}
+		})
+	}
+}
+
+func TestValidateEnum(t *testing.T) {
+	var testEnums = []struct {
+		name           string
+		value          string
+		dataItem       converterUtils.PDBxItem
+		expectedResult string
+	}{
+		{"boolean true to yes", "true", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", EnumValues: []string{"YES", "NO"}, PDBxEnumValues: []string{}}, "YES"},
+		{"boolean false to NO", "false", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", EnumValues: []string{"YES", "NO"}, PDBxEnumValues: []string{}}, "NO"},
+		{"Titan as microscope name (enum in this case irrelevant)", "FEI titan4", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "microscope_model", EnumValues: []string{"YES", "NO"}, PDBxEnumValues: []string{}}, "TFS KRIOS"},
+		{"Microscope in enum", "my microscope", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "microscope_model", EnumValues: []string{"my microscope", "another microscope"}, PDBxEnumValues: []string{}}, "my microscope"},
+		{"Microscope not in enum", "my microscope", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "microscope_model", EnumValues: []string{"TFS KRIOS", "TFS GLACIOS", "TFS TALOS"}, PDBxEnumValues: []string{}}, "MY MICROSCOPE"},
+		{"Microscope in enum", "TFS glacios", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "microscope_model", EnumValues: []string{"TFS KRIOS", "TFS GLACIOS", "TFS TALOS"}, PDBxEnumValues: []string{}}, "TFS GLACIOS"},
+		{"Rewrite BrightField with space (enum in this case irrelevant)", "BrightField", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "mode", EnumValues: []string{"TFS KRIOS", "TFS GLACIOS", "TFS TALOS"}, PDBxEnumValues: []string{}}, "BRIGHT FIELD"},
+		{"Bright field case sensitive match PDBx enum", "bright field", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "mode", EnumValues: []string{"TFS KRIOS", "TFS GLACIOS", "TFS TALOS"}, PDBxEnumValues: []string{"BRIGHT FIELD", "SOMETHING"}}, "BRIGHT FIELD"},
+		{"Rewrite FieldEmission with space (enum in this case irrelevant)", "FieldEmission", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "electron_source", EnumValues: []string{}, PDBxEnumValues: []string{}}, "FIELD EMISSION GUN"},
+		{"Bright field case sensitive", "Field Emission Gun", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "mode", EnumValues: []string{"BRIGHT FIELD", "SOMETHING"}, PDBxEnumValues: []string{"FIELD EMISSION GUN", "SOMETHING"}}, "FIELD EMISSION GUN"},
+		{"In enum case sensitive", "NItrogen", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", EnumValues: []string{"ETHANE", "NITROGEN", "OTHER"}, PDBxEnumValues: []string{}}, "NITROGEN"},
+		{"Grid material matching RegEx on Graphene", "Graphene", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "GRAPHENE OXIDE"},
+		{"Grid material matching RegEx on silicon", "silicon", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "SILICON NITRIDE"},
+		{"Grid material matching chemical composition 1", "Cu", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "COPPER"},
+		{"Grid material matching chemical composition 2", "Cu/Pd", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "COPPER/PALLADIUM"},
+		{"Grid material matching chemical composition 3", "Cu/Rh", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "COPPER/RHODIUM"},
+		{"Grid material matching chemical composition 4", "Au", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "GOLD"},
+		{"Grid material matching chemical composition 5", "Ni", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "NICKEL"},
+		{"Grid material matching chemical composition 6", "Ni/Ti", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "NICKEL/TITANIUM"},
+		{"Grid material matching chemical composition 7", "Pt", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "PLATINUM"},
+		{"Grid material matching chemical composition 8", "W", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "TUNGSTEN"},
+		{"Grid material matching chemical composition 9", "Ti", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "TITANIUM"},
+		{"Grid material matching chemical composition 10", "Mo", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "MOLYBDENUM"},
+		{"Grid material matching enum case sensitive", "COpper", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "COPPER"},
+		{"Detector is Falcon I (enum in this case irrelevant)", "falcon 1", converterUtils.PDBxItem{CategoryID: "_em_image_recording", Name: "film_or_detector_model", EnumValues: []string{}, PDBxEnumValues: []string{}}, "FEI FALCON I (4k x 4k)"},
+		{"Detector is Falcon II (enum in this case irrelevant)", "Falcon ii", converterUtils.PDBxItem{CategoryID: "_em_image_recording", Name: "film_or_detector_model", EnumValues: []string{}, PDBxEnumValues: []string{}}, "FEI FALCON II (4k x 4k)"},
+		{"Detector is Falcon III (enum in this case irrelevant)", "FALCON3 ", converterUtils.PDBxItem{CategoryID: "_em_image_recording", Name: "film_or_detector_model", EnumValues: []string{}, PDBxEnumValues: []string{}}, "FEI FALCON III (4k x 4k)"},
+		{"Detector is Falcon IV (enum in this case irrelevant)", "FalconIV", converterUtils.PDBxItem{CategoryID: "_em_image_recording", Name: "film_or_detector_model", EnumValues: []string{}, PDBxEnumValues: []string{}}, "FEI FALCON IV (4k x 4k)"},
+		{"Detector is something else from enum", "GATAN multiscan", converterUtils.PDBxItem{CategoryID: "_em_image_recording", Name: "film_or_detector_model", PDBxEnumValues: []string{"GATAN MULTISCAN", "DECTRIS ELA (1k x 0.5k)"}}, "GATAN MULTISCAN"},
+		{"Detector is Falcon IV (enum in this case irrelevant)", "FalconIV", converterUtils.PDBxItem{CategoryID: "_em_image_recording", Name: "film_or_detector_model", EnumValues: []string{}, PDBxEnumValues: []string{}}, "FEI FALCON IV (4k x 4k)"},
+		{"Funding from enum", "Swiss National Science Foundation", converterUtils.PDBxItem{CategoryID: "_pdbx_audit_support", Name: "funding_organization", PDBxEnumValues: []string{"Swiss National Science Foundation", "Swiss Cancer League"}}, "Swiss National Science Foundation"},
+		{"Funding from enum", "SNSF", converterUtils.PDBxItem{CategoryID: "_pdbx_audit_support", Name: "funding_organization", PDBxEnumValues: []string{"Swiss National Science Foundation", "Swiss Cancer League"}}, "Other government"},
+	}
+
+	for _, test := range testEnums {
+
+		testname := fmt.Sprintf("%v", test.name)
+		t.Run(testname, func(t *testing.T) {
+			gotValue := validateEnum(test.value, test.dataItem)
+
+			if gotValue != test.expectedResult {
+				t.Errorf("got %v, want %v", gotValue, test.expectedResult)
+			}
+		})
+	}
+}

--- a/parser/valueCheckers.go
+++ b/parser/valueCheckers.go
@@ -1,0 +1,256 @@
+package parser
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/osc-em/converter-OSCEM-to-mmCIF/converterUtils"
+)
+
+func validateDateIsRFC3339(date string) string {
+	t, err := time.Parse(time.RFC3339, date)
+	if err != nil {
+		log.Printf(
+			"Date seems to be in the wrong format! We expect RFC3339 format, provided date %s is not.", date)
+		return ""
+	}
+	return t.Format(time.DateOnly)
+}
+
+func validateRange(value string, dataItem converterUtils.PDBxItem, unitOSCEM string, nameOSCEM string) (bool, error) {
+	rMin := dataItem.RangeMin
+	rMax := dataItem.RangeMax
+	unitPDBx := dataItem.Unit
+	namePDBx := dataItem.CategoryID + "." + dataItem.Name
+	var unitsSame bool
+	var errorMessage string
+	var unitsError error
+	if unitOSCEM == "" && unitPDBx == "" {
+		// both OSCEM and PDBx have no units definition
+		unitsSame = true
+	} else if unitOSCEM == "" && unitPDBx != "" {
+		errorMessage = fmt.Sprintf(
+			"No units defined for %s in OSCEM! Analogous property %s in PDBx has %s units. Value will still be used in mmCIF file!",
+			nameOSCEM, namePDBx, unitPDBx)
+		unitsSame = false
+		unitsError = errors.New(errorMessage)
+		return true, unitsError
+	} else if unitOSCEM != "" && unitPDBx == "" {
+		errorMessage = fmt.Sprintf(
+			"No units defined for %s in PDBx! Analogous property %s in OSCEM has %s units. Value will still be used in mmCIF file!",
+			namePDBx, nameOSCEM, unitOSCEM)
+		unitsSame = false
+		unitsError = errors.New(errorMessage)
+		return true, unitsError
+	} else {
+		explicitUnitOSCEM, ok := converterUtils.UnitsName[unitOSCEM]
+		if !ok {
+			errorMessage = fmt.Sprintf(
+				"No explicit unit name is specified for property %s in OSCEM, only a short name %s. Value will still be used in mmCIF file!",
+				nameOSCEM, unitOSCEM)
+			unitsSame = false
+			unitsError = errors.New(errorMessage)
+			return true, unitsError
+		} else {
+			unitsError = nil
+		}
+		unitsSame = explicitUnitOSCEM == unitPDBx
+	}
+	// FIXME: when units are settled, do conversion when possible!
+	if unitsSame {
+		v, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			errorMessage = fmt.Sprintf("JSON value %s not numeric, but supposed to be", value)
+			return false, errors.New(errorMessage)
+		}
+		rMin, err := strconv.ParseFloat(rMin, 64)
+		if err != nil {
+			rMin = math.NaN()
+		}
+		rMax, err := strconv.ParseFloat(rMax, 64)
+		if err != nil {
+			rMax = math.NaN()
+		}
+		if math.IsNaN(rMin) && math.IsNaN(float64(rMax)) {
+			return true, unitsError
+		} else if math.IsNaN(rMin) {
+			return float64(v) <= rMax, unitsError
+		} else if math.IsNaN(rMax) {
+			return float64(v) >= rMin, unitsError
+		} else {
+			return float64(v) >= rMin && float64(v) <= rMax, unitsError
+		}
+	} else {
+		errorMessage = fmt.Sprintf(
+			"Units for analogous properties %s in OSCEM and %s in PDBx  don't match!"+
+				" Implement a converter from %s in OSCEM to %s expected by PDBx. Value will still be used in mmCIF file!",
+			nameOSCEM, namePDBx, unitOSCEM, unitPDBx)
+		unitsError = errors.New(errorMessage)
+		return true, unitsError
+	}
+
+}
+func validateEnum(value string, dataItem converterUtils.PDBxItem) string {
+	enumFromEMDB := dataItem.EnumValues
+	enumFromPDBx := dataItem.PDBxEnumValues
+	namePDBx := dataItem.CategoryID + "." + dataItem.Name
+	if value == "true" {
+		return "YES"
+	} else if value == "false" {
+		return "NO"
+	}
+
+	if namePDBx == "_em_imaging.microscope_model" {
+		reTitan := regexp.MustCompile(`(?i)titan`)
+		if reTitan.MatchString(value) {
+			return "TFS KRIOS"
+		}
+	} else if namePDBx == "_em_imaging.mode" {
+		if value == "BrightField" {
+			return "BRIGHT FIELD"
+		}
+	} else if namePDBx == "_em_imaging.electron_source" {
+		if value == "FieldEmission" {
+			return "FIELD EMISSION GUN"
+		}
+	}
+	for i := range enumFromEMDB {
+		if strings.EqualFold(enumFromEMDB[i], value) {
+			value = enumFromEMDB[i]
+			return value
+		}
+	}
+	// scan through both enums
+	for i := range enumFromPDBx {
+		if strings.EqualFold(enumFromPDBx[i], value) {
+			value = enumFromPDBx[i]
+			return value
+		}
+	}
+	if namePDBx == "_em_imaging.illumination_mode" {
+		reFloodBeam := regexp.MustCompile(`(?i)parallel`)
+		if reFloodBeam.MatchString(value) {
+			return "FLOOD BEAM"
+		}
+	}
+	if namePDBx == "_pdbx_contact_author.role" {
+		reRole := regexp.MustCompile(`(?i)(principal investigator|group leader|pi)`)
+		if reRole.MatchString(value) {
+			return "principal investigator/group leader"
+		}
+	}
+	// add additional matching mechanism for grid material by chemical element name/ regular expression
+	if namePDBx == "_em_sample_support.grid_material" {
+
+		reGraphene := regexp.MustCompile(`(?i)graphene`)
+		reSilicon := regexp.MustCompile(`(?i)silicon`)
+		if reGraphene.MatchString(value) {
+			return "GRAPHENE OXIDE"
+		} else if reSilicon.MatchString(value) {
+			return "SILICON NITRIDE"
+		}
+		switch value {
+		case "Cu":
+			return "COPPER"
+		case "Cu/Pd":
+			return "COPPER/PALLADIUM"
+		case "Cu/Rh":
+			return "COPPER/RHODIUM"
+		case "Au":
+			return "GOLD"
+		case "Ni":
+			return "NICKEL"
+		case "Ni/Ti":
+			return "NICKEL/TITANIUM"
+		case "Pt":
+			return "PLATINUM"
+		case "W":
+			return "TUNGSTEN"
+		case "Ti":
+			return "TITANIUM"
+		case "Mo":
+			return "MOLYBDENUM"
+		}
+
+	} else if namePDBx == "_em_image_recording.film_or_detector_model" {
+		// add additional matching mechanism for "Falcon" detector model by regular expression; other don't seem feasible
+
+		reFalconI := regexp.MustCompile(`(?i)falcon[\s_]*?(1|I)`)
+		reFalconII := regexp.MustCompile(`(?i)falcon[\s_]*?(2|II)`)
+		reFalconIII := regexp.MustCompile(`(?i)falcon[\s_]*?(3|III)`)
+		reFalconIV := regexp.MustCompile(`(?i)falcon[\s_]*?(4|IV)`)
+		switch {
+		case reFalconIV.MatchString(value):
+			return "FEI FALCON IV (4k x 4k)"
+		case reFalconIII.MatchString(value):
+			return "FEI FALCON III (4k x 4k)"
+		case reFalconII.MatchString(value):
+			return "FEI FALCON II (4k x 4k)"
+		case reFalconI.MatchString(value):
+			return "FEI FALCON I (4k x 4k)"
+		}
+	}
+
+	log.Printf("value %v is not in enum %s!", value, namePDBx)
+	// if not found in enum list and it's a funding organisation, put a certain string
+	if namePDBx == "_pdbx_audit_support.funding_organization" {
+		return "Other government"
+	}
+	// // if no match and enum contains option for OTHER, choose it
+	// if converterUtils.SliceContains(enumFromEMDB, "OTHER") || converterUtils.SliceContains(enumFromPDBx, "OTHER"){
+	// 	return "OTHER"
+	// }
+
+	return strings.ToUpper(value)
+}
+
+func checkValue(dataItem converterUtils.PDBxItem, value string, jsonKey string, unitsOSCEM string) string {
+
+	//now based on the found struct implement range matching, units matching and enum matching
+	if dataItem.ValueType == "int" || dataItem.ValueType == "float" {
+		namePDBx := dataItem.CategoryID + "." + dataItem.Name
+		// in OSCEM defocus is negative value and overfocus is positive. In PDBx it's vice versa if string starts with  minus, ut it off, otherwise add a - prefix
+		if namePDBx == "_em_imaging.nominal_defocus_min" ||
+			namePDBx == "_em_imaging.calibrated_defocus_min" ||
+			namePDBx == "_em_imaging.nominal_defocus_max" ||
+			namePDBx == "_em_imaging.calibrated_defocus_max" {
+			// change the sign negative to positive and vice versa
+			if value[0] == 45 {
+				value = value[1:]
+			} else {
+				value = "-" + value
+			}
+		}
+		validatedRange, err := validateRange(value, dataItem, unitsOSCEM, jsonKey)
+		if err != nil {
+			errorNumeric := fmt.Sprintf("JSON value %s not numeric, but supposed to be", value)
+			if err.Error() == errorNumeric {
+				return "?"
+			} else {
+				// FIXME when units conversion is implemented, handle this error
+				log.Println(err.Error())
+			}
+		}
+		if !validatedRange {
+			log.Printf(
+				"Value %s of property %s is not in range of [ %s, %s ]!\n", value, jsonKey, dataItem.RangeMin, dataItem.RangeMax)
+		}
+	} else if dataItem.ValueType == "yyyy-mm-dd" {
+		value = validateDateIsRFC3339(value)
+	} else if len(dataItem.EnumValues) > 0 || len(dataItem.PDBxEnumValues) > 0 {
+		value = validateEnum(value, dataItem)
+	}
+
+	if strings.Contains(value, " ") {
+		value = fmt.Sprintf("'%s' ", value) // if name contains whitespaces enclose it in single quotes
+	} else {
+		value = fmt.Sprintf("%s ", value) // take value as is
+	}
+	return value
+}

--- a/parser/writeMmCif_test.go
+++ b/parser/writeMmCif_test.go
@@ -62,130 +62,6 @@ func TestGetKeyByValue(t *testing.T) {
 // 	}
 // }
 
-func TestValidateDateIsRFC3339(t *testing.T) {
-	var testDate = []struct {
-		name           string
-		date           string
-		expectedResult string
-	}{
-		{"date is in correct format UTC+3", "2020-12-09T16:09:53+03:00", "2020-12-09"},
-		{"date is in correct format UTC+0 Z", "2020-12-09T16:09:53Z", "2020-12-09"},
-		{"date is in correct format UTC+0", "2020-12-09T16:09:53+02:00", "2020-12-09"},
-		{"date is in correct format UTC-1", "2020-12-09T16:09:53-01:00", "2020-12-09"},
-		{"date is in correct format but space instead of T does not work in time.Parse!", "2020-12-09 16:09:53-01:00", ""},
-		{"date is in correct format date only but no specified time- does not work in time.Parse!", "2020-12-09", ""},
-		{"date is in wrong format", "July, 17th 2017", ""},
-	}
-
-	for _, test := range testDate {
-
-		testname := fmt.Sprintf("%v", test.name)
-		t.Run(testname, func(t *testing.T) {
-			gotValue := validateDateIsRFC3339(test.date)
-
-			if gotValue != test.expectedResult {
-				t.Errorf("got %v, want %v", gotValue, test.expectedResult)
-			}
-		})
-	}
-}
-
-func TestValidateRange(t *testing.T) {
-	var testRange = []struct {
-		name           string
-		value          string
-		dataItem       converterUtils.PDBxItem
-		unitOSCEM      string
-		nameOSCEM      string
-		expectedResult bool
-		expectedError  string
-	}{
-		{"no units defined in OSCEM and PDBx", "27", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "", ValueType: "float", RangeMin: "0", RangeMax: "300", EnumValues: []string{}, PDBxEnumValues: []string{}}, "", "myOSCEMname", true, ""},
-		{"no units defined in OSCEM", "0.7", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "%", ValueType: "float", RangeMin: "0", RangeMax: "100", EnumValues: []string{}, PDBxEnumValues: []string{}}, "", "myOSCEMname", true, "No units defined for myOSCEMname in OSCEM! Analogous property cat1.name1 in PDBx has % units. Value will still be used in mmCIF file!"},
-		{"no units defined in PDBx", "5", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "", ValueType: "float", RangeMin: "0", RangeMax: "1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "Da", "myOSCEMname", true, "No units defined for cat1.name1 in PDBx! Analogous property myOSCEMname in OSCEM has Da units. Value will still be used in mmCIF file!"},
-		{"no explicit name of units defined in OSCEM", "0.5", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "mol", ValueType: "float", RangeMin: "0", RangeMax: "1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "mM", "myOSCEMname", true, "No explicit unit name is specified for property myOSCEMname in OSCEM, only a short name mM. Value will still be used in mmCIF file!"},
-		{"units don't match in OSCEM and PDBx", "2", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "second", ValueType: "float", RangeMin: "0", RangeMax: "10", EnumValues: []string{}, PDBxEnumValues: []string{}}, "s", "myOSCEMname", true, "Units for analogous properties myOSCEMname in OSCEM and cat1.name1 in PDBx  don't match! Implement a converter from s in OSCEM to second expected by PDBx. Value will still be used in mmCIF file!"},
-		{"units match but value not numeric", "zero", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "electron_volts", ValueType: "float", RangeMin: "-1", RangeMax: "1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "eV", "myOSCEMname", false, "JSON value zero not numeric, but supposed to be"},
-		{"units match but value is greater than maximum allowed in PDBx", "10", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "electron_volts", ValueType: "float", RangeMin: "-1", RangeMax: "1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "eV", "myOSCEMname", false, ""},
-		{"units match but value is smaller than minimum allowed in PDBx", "-1.2", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "electron_volts", ValueType: "float", RangeMin: "-1", RangeMax: "1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "eV", "myOSCEMname", false, ""},
-		{"units match and tange undefined by PDBx", "0", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "electron_volts", ValueType: "float", EnumValues: []string{}, PDBxEnumValues: []string{}}, "eV", "myOSCEMname", true, ""},
-		{"units match and value is in range allowed by PDBx", "0", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "electron_volts", ValueType: "float", RangeMin: "-1", RangeMax: "1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "eV", "myOSCEMname", true, ""},
-		{"units match and value is in range allowed by PDBx (no max)", "0", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "electron_volts", ValueType: "float", RangeMin: "-1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "eV", "myOSCEMname", true, ""},
-		{"units match and value is in range allowed by PDBx (no min)", "0", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", Unit: "electron_volts", ValueType: "float", RangeMax: "1", EnumValues: []string{}, PDBxEnumValues: []string{}}, "eV", "myOSCEMname", true, ""},
-	}
-
-	for _, test := range testRange {
-
-		testname := fmt.Sprintf("%v", test.name)
-		t.Run(testname, func(t *testing.T) {
-			gotValue, gotError := validateRange(test.value, test.dataItem, test.unitOSCEM, test.nameOSCEM)
-
-			if gotError != nil {
-				if gotError.Error() != test.expectedError {
-					t.Errorf("got error %v, wanted %v", gotError.Error(), test.expectedError)
-				}
-			}
-			if gotValue != test.expectedResult {
-				t.Errorf("got %v, want %v", gotValue, test.expectedResult)
-			}
-		})
-	}
-}
-
-func TestValidateEnum(t *testing.T) {
-	var testEnums = []struct {
-		name           string
-		value          string
-		dataItem       converterUtils.PDBxItem
-		expectedResult string
-	}{
-		{"boolean true to yes", "true", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", EnumValues: []string{"YES", "NO"}, PDBxEnumValues: []string{}}, "YES"},
-		{"boolean false to NO", "false", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", EnumValues: []string{"YES", "NO"}, PDBxEnumValues: []string{}}, "NO"},
-		{"Titan as microscope name (enum in this case irrelevant)", "FEI titan4", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "microscope_model", EnumValues: []string{"YES", "NO"}, PDBxEnumValues: []string{}}, "TFS KRIOS"},
-		{"Microscope in enum", "my microscope", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "microscope_model", EnumValues: []string{"my microscope", "another microscope"}, PDBxEnumValues: []string{}}, "my microscope"},
-		{"Microscope not in enum", "my microscope", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "microscope_model", EnumValues: []string{"TFS KRIOS", "TFS GLACIOS", "TFS TALOS"}, PDBxEnumValues: []string{}}, "MY MICROSCOPE"},
-		{"Microscope in enum", "TFS glacios", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "microscope_model", EnumValues: []string{"TFS KRIOS", "TFS GLACIOS", "TFS TALOS"}, PDBxEnumValues: []string{}}, "TFS GLACIOS"},
-		{"Rewrite BrightField with space (enum in this case irrelevant)", "BrightField", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "mode", EnumValues: []string{"TFS KRIOS", "TFS GLACIOS", "TFS TALOS"}, PDBxEnumValues: []string{}}, "BRIGHT FIELD"},
-		{"Bright field case sensitive match PDBx enum", "bright field", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "mode", EnumValues: []string{"TFS KRIOS", "TFS GLACIOS", "TFS TALOS"}, PDBxEnumValues: []string{"BRIGHT FIELD", "SOMETHING"}}, "BRIGHT FIELD"},
-		{"Rewrite FieldEmission with space (enum in this case irrelevant)", "FieldEmission", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "electron_source", EnumValues: []string{}, PDBxEnumValues: []string{}}, "FIELD EMISSION GUN"},
-		{"Bright field case sensitive", "Field Emission Gun", converterUtils.PDBxItem{CategoryID: "_em_imaging", Name: "mode", EnumValues: []string{"BRIGHT FIELD", "SOMETHING"}, PDBxEnumValues: []string{"FIELD EMISSION GUN", "SOMETHING"}}, "FIELD EMISSION GUN"},
-		{"In enum case sensitive", "NItrogen", converterUtils.PDBxItem{CategoryID: "cat1", Name: "name1", EnumValues: []string{"ETHANE", "NITROGEN", "OTHER"}, PDBxEnumValues: []string{}}, "NITROGEN"},
-		{"Grid material matching RegEx on Graphene", "Graphene", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "GRAPHENE OXIDE"},
-		{"Grid material matching RegEx on silicon", "silicon", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "SILICON NITRIDE"},
-		{"Grid material matching chemical composition 1", "Cu", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "COPPER"},
-		{"Grid material matching chemical composition 2", "Cu/Pd", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "COPPER/PALLADIUM"},
-		{"Grid material matching chemical composition 3", "Cu/Rh", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "COPPER/RHODIUM"},
-		{"Grid material matching chemical composition 4", "Au", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "GOLD"},
-		{"Grid material matching chemical composition 5", "Ni", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "NICKEL"},
-		{"Grid material matching chemical composition 6", "Ni/Ti", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "NICKEL/TITANIUM"},
-		{"Grid material matching chemical composition 7", "Pt", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "PLATINUM"},
-		{"Grid material matching chemical composition 8", "W", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "TUNGSTEN"},
-		{"Grid material matching chemical composition 9", "Ti", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "TITANIUM"},
-		{"Grid material matching chemical composition 10", "Mo", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "MOLYBDENUM"},
-		{"Grid material matching enum case sensitive", "COpper", converterUtils.PDBxItem{CategoryID: "_em_sample_support", Name: "grid_material", EnumValues: []string{"COPPER", "COPPER/PALLADIUM", "COPPER/RHODIUM", "GOLD", "GRAPHENE OXIDE", "NICKEL", "NICKEL/TITANIUM", "PLATINUM", "SILICON NITRIDE", "TUNGSTEN", "TITANIUM", "MOLYBDENUM"}}, "COPPER"},
-		{"Detector is Falcon I (enum in this case irrelevant)", "falcon 1", converterUtils.PDBxItem{CategoryID: "_em_image_recording", Name: "film_or_detector_model", EnumValues: []string{}, PDBxEnumValues: []string{}}, "FEI FALCON I (4k x 4k)"},
-		{"Detector is Falcon II (enum in this case irrelevant)", "Falcon ii", converterUtils.PDBxItem{CategoryID: "_em_image_recording", Name: "film_or_detector_model", EnumValues: []string{}, PDBxEnumValues: []string{}}, "FEI FALCON II (4k x 4k)"},
-		{"Detector is Falcon III (enum in this case irrelevant)", "FALCON3 ", converterUtils.PDBxItem{CategoryID: "_em_image_recording", Name: "film_or_detector_model", EnumValues: []string{}, PDBxEnumValues: []string{}}, "FEI FALCON III (4k x 4k)"},
-		{"Detector is Falcon IV (enum in this case irrelevant)", "FalconIV", converterUtils.PDBxItem{CategoryID: "_em_image_recording", Name: "film_or_detector_model", EnumValues: []string{}, PDBxEnumValues: []string{}}, "FEI FALCON IV (4k x 4k)"},
-		{"Detector is something else from enum", "GATAN multiscan", converterUtils.PDBxItem{CategoryID: "_em_image_recording", Name: "film_or_detector_model", PDBxEnumValues: []string{"GATAN MULTISCAN", "DECTRIS ELA (1k x 0.5k)"}}, "GATAN MULTISCAN"},
-		{"Detector is Falcon IV (enum in this case irrelevant)", "FalconIV", converterUtils.PDBxItem{CategoryID: "_em_image_recording", Name: "film_or_detector_model", EnumValues: []string{}, PDBxEnumValues: []string{}}, "FEI FALCON IV (4k x 4k)"},
-		{"Funding from enum", "Swiss National Science Foundation", converterUtils.PDBxItem{CategoryID: "_pdbx_audit_support", Name: "funding_organization", PDBxEnumValues: []string{"Swiss National Science Foundation", "Swiss Cancer League"}}, "Swiss National Science Foundation"},
-		{"Funding from enum", "SNSF", converterUtils.PDBxItem{CategoryID: "_pdbx_audit_support", Name: "funding_organization", PDBxEnumValues: []string{"Swiss National Science Foundation", "Swiss Cancer League"}}, "Other government"},
-	}
-
-	for _, test := range testEnums {
-
-		testname := fmt.Sprintf("%v", test.name)
-		t.Run(testname, func(t *testing.T) {
-			gotValue := validateEnum(test.value, test.dataItem)
-
-			if gotValue != test.expectedResult {
-				t.Errorf("got %v, want %v", gotValue, test.expectedResult)
-			}
-		})
-	}
-}
-
 func TestToEMDB(t *testing.T) {
 	var testCases = []struct {
 		name          string
@@ -432,7 +308,7 @@ func TestToPDB2(t *testing.T) {
 			"",
 		},
 		{
-			"Category and value present in both mmCIF and metadata and both have one instance, fields shoud complement each other",
+			"Category and value present in both mmCIF and metadata and both have one instance, fields should complement each other",
 			map[string]string{"mydata1": "_entity_poly.type", "mydata2": "_entity_poly.pdbx_seq_one_letter_code", "mydata3": "_entity_poly.nstd_monomer"},
 			map[string][]converterUtils.PDBxItem{
 				"_entity_poly": {
@@ -448,7 +324,7 @@ func TestToPDB2(t *testing.T) {
 			"",
 		},
 		{
-			"Category and value present in both mmCIF and metadata and both have the same number of instances(>1), fields shoud complement each other within loop",
+			"Category and value present in both mmCIF and metadata and both have the same number of instances(>1), fields should complement each other within loop",
 			map[string]string{"mydata1": "_pdbx_nonpoly_scheme.mon_id", "mydata2": "_pdbx_nonpoly_scheme.auth_seq_num", "mydata3": "_pdbx_nonpoly_scheme.pdb_mon_id", "mydata4": "_pdbx_nonpoly_scheme.pdb_ins_code"},
 			map[string][]converterUtils.PDBxItem{
 				"_pdbx_nonpoly_scheme": {
@@ -461,7 +337,7 @@ func TestToPDB2(t *testing.T) {
 			map[string][]string{"mydata1": {"CU", "ZN"}, "mydata2": {"218", "202"}, "mydata3": {"CU", "ZN"}, "mydata4": {"hello", "world"}},
 			map[string][]string{},
 			"testData/exampleBothLoop.cif",
-			"data_K3DAK4\n#\nloop_\n_pdbx_nonpoly_scheme.auth_seq_num\n_pdbx_nonpoly_scheme.pdb_mon_id\n_pdbx_nonpoly_scheme.asym_id\n_pdbx_nonpoly_scheme.entity_id\n_pdbx_nonpoly_scheme.mon_id\n_pdbx_nonpoly_scheme.ndb_seq_num\n_pdbx_nonpoly_scheme.pdb_seq_num\n_pdbx_nonpoly_scheme.auth_mon_id\n_pdbx_nonpoly_scheme.pdb_strand_id\n_pdbx_nonpoly_scheme.pdb_ins_code\n218 CU B 2 FE 1 201 'FE a' A . \n202 ZN C 3 ZN 1 202 'ZN b' A . \n#\n#\n",
+			"data_K3DAK4\n#\nloop_\n_pdbx_nonpoly_scheme.asym_id\n_pdbx_nonpoly_scheme.entity_id\n_pdbx_nonpoly_scheme.mon_id\n_pdbx_nonpoly_scheme.ndb_seq_num\n_pdbx_nonpoly_scheme.pdb_seq_num\n_pdbx_nonpoly_scheme.auth_mon_id\n_pdbx_nonpoly_scheme.pdb_strand_id\n_pdbx_nonpoly_scheme.pdb_ins_code\nB 2 FE 1 201 'FE a' A . \nC 3 ZN 1 202 'ZN b' A . \n#\n#\n",
 			"",
 		},
 	}
@@ -471,7 +347,7 @@ func TestToPDB2(t *testing.T) {
 		t.Run(testname, func(t *testing.T) {
 			dictFile, _ := os.Open(test.pathExisting)
 			defer dictFile.Close()
-			gotValue, gotError := SupplementCoordinatesFromFile(test.namesMap, test.PDBxItems, test.jsonValues, test.unitsOSCEM, dictFile)
+			gotValue, gotError := SupplementCoordinates(test.namesMap, test.PDBxItems, test.jsonValues, test.unitsOSCEM, dictFile)
 
 			if gotError != nil {
 				if gotError.Error() != test.expectedError {


### PR DESCRIPTION
In issue #19 in [this comment ](https://github.com/osc-em/converter-OSCEM-to-mmCIF/issues/19#issuecomment-2678806414) I explained why it might me problematic to supplement the data items when number of entities is the same and >1. 
As a default converter in such cases would just take all info about this category from the provided coordinates file